### PR TITLE
Set the window tray icon text

### DIFF
--- a/src/WindowSnipping.ahk
+++ b/src/WindowSnipping.ahk
@@ -71,6 +71,7 @@ Menu, Tray, Icon, % script.iconfile
 IniRead, ShowUsage, % script.configfile, Settings, ShowUsage, % true
 IniRead, SWW,  % script.configfile, Settings, StartWithWindows
 
+Menu, Tray, Tip, Window Snipping Tool
 Menu, Tray, NoStandard ;removes default options
 Menu, Tray, Add	; to divide from standard menu, remove when above line is uncommented
 Menu, Tray, Add, Hotkeys, HotkeysGUI


### PR DESCRIPTION
Currently, when uncompiled, the Window Snipping Tool tray icon shows "WindowSnipping.ahk". This change sets it to "Window Snipping Tool" instead.