### PR TITLE
Fixes DPI mismatch problems when docking/undocking laptop to external monitor(s) or when DPI changes

### DIFF
--- a/src/WindowSnipping.ahk
+++ b/src/WindowSnipping.ahk
@@ -104,6 +104,9 @@ else
 	Gosub SetHotkeys
 }
 
+; If monitor count changes, reload. This is a hack to re-initalize DPI changes for new configuration.
+OnMessage(0x007E, "ReloadScript")
+
 if (ShowUsage)
 	Gosub ShowUsageGUI
 return
@@ -1623,6 +1626,10 @@ Base64Enc( ByRef Bin, nBytes, LineLength := 64, LeadingSpaces := 0 )
 	Loop % Ceil( StrLen(B64) / LineLength )
 		B .= Format("{1:" LeadingSpaces "s}","" ) . SubStr( B64, N += LineLength, LineLength ) . "`n"
 	Return RTrim( B,"`n" )
+}
+
+ReloadScript() {
+  Reload
 }
 
 ;*******************************************************


### PR DESCRIPTION
When the script starts it maps out the monitors and their DPI configuration. When that changes, the script doesn't react to the new environment and therefore screen capture fails to select the region expected.

This change adds logic to restart the script if the any Display configuration changes in order to fix this DPI problem mismatch.

If there's a better solution than restarting the script, that would be preferable. I wasn't familiar enough with the guts of the script internals to do something less drastic.